### PR TITLE
ACTION-2120: UIA: clean up mapping for aria-haspopup

### DIFF
--- a/core-aam/core-aam.html
+++ b/core-aam/core-aam.html
@@ -1928,7 +1928,7 @@ var mappingTableLabels = {
                         <li>Expose as object attribute <code>haspopup:true</code></li>
                       </ul>
                   </td>
-                  <td>Expose state of the pop-up activities as <code>"expanded"</code> in the <code>ExpandCollapseState</code> property of the <code>ExpandCollapse</code> Control Pattern</td>
+                  <td>Implement <code>ExpandCollapse</code> Control Pattern, set the <code>ExpandCollapseState</code> property to match <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)</td>
                   <td>
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code>
@@ -1947,9 +1947,7 @@ var mappingTableLabels = {
                     </ul>
                   </td>
                   <td>
-                    <ul>
-                      <li>If explicitly set to <code>"false"</code>, expose state of the pop-up activities as <code>"collapsed"</code> in the <code>ExpandCollapseState</code> property of the <code>ExpandCollapse</code> Control Pattern</li>
-                      <li>Otherwise, <a href="#not_mapped">Not mapped*</a></li>
+                    <a href="#not_mapped">Not mapped*</a></li>
                     </ul>
                   </td>
                   <td><a href="#not_mapped">Not mapped*</a></td>
@@ -1963,7 +1961,7 @@ var mappingTableLabels = {
                         <li>Expose as object attribute <code>haspopup:dialog</code></li>
                       </ul>
                   </td>
-                  <td>Expose state of the pop-up activities as <code>"expanded"</code> in the <code>ExpandCollapseState</code> property of the <code>ExpandCollapse</code> Control Pattern</td>
+                  <td>Implement <code>ExpandCollapse</code> Control Pattern, set the <code>ExpandCollapseState</code> property to match <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)</td>
                   <td>
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code>
@@ -1981,7 +1979,7 @@ var mappingTableLabels = {
                         <li>Expose as object attribute <code>haspopup:listbox</code></li>
                       </ul>
                   </td>
-                  <td>Expose state of the pop-up activities as <code>"expanded"</code> in the <code>ExpandCollapseState</code> property in the <code>ExpandCollapse</code> Control Pattern</td>
+                  <td>Implement <code>ExpandCollapse</code> Control Pattern, set the <code>ExpandCollapseState</code> property to match <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)</td>
                   <td>
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code>
@@ -1999,7 +1997,7 @@ var mappingTableLabels = {
                       <li>Expose as object attribute <code>haspopup:menu</code></li>
                     </ul>
                   </td>
-                  <td>Expose state of the pop-up activities as <code>"expanded"</code> in the <code>ExpandCollapseState</code> property of the <code>ExpandCollapse</code> Control Pattern</td>
+                  <td>Implement <code>ExpandCollapse</code> Control Pattern, set the <code>ExpandCollapseState</code> property to match <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)</td>
                   <td>
                     <ul>
                       <li>Expose <code>STATE_HAS_POPUP</code>
@@ -2017,7 +2015,7 @@ var mappingTableLabels = {
                       <li>Expose as object attribute <code>haspopup:tree</code></li>
                     </ul>
                   </td>
-                  <td>Expose state of the pop-up activities as <code>"expanded"</code> in the <code>ExpandCollapseState</code> property of the <code>ExpandCollapse</code> Control Pattern</td>
+                  <td>Implement <code>ExpandCollapse</code> Control Pattern, set the <code>ExpandCollapseState</code> property to match <a class="state-reference" href="#aria-expanded"><code>aria-expanded</code></a> (state)</td>
                   <td>
                     <ul>
 		              <li>Expose <code>STATE_HAS_POPUP</code>


### PR DESCRIPTION
Clean up the wording with the current UIA implementer expecation.
Currently UIA doesn't provide a way to expose richer semantic of
aria-haspopup values, so in all non-trivial cases we're using same
mapping as in "true" value case. For "false" the mapping would require
to not implement ExpandCollapse pattern which is reflected in new "Not
mapped" value